### PR TITLE
Add minimal UI components for build

### DIFF
--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const Badge = React.forwardRef(function Badge({ className = '', ...props }, ref) {
+  return <span ref={ref} className={`px-2 py-1 rounded text-sm ${className}`} {...props} />
+})

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import clsx from 'clsx'
+
+const variants = {
+  default: 'bg-mi-mundo-yellow text-mi-mundo-dark hover:bg-mi-mundo-yellow/90',
+  ghost: 'bg-transparent hover:bg-mi-mundo-light/10',
+}
+
+export const Button = React.forwardRef(function Button(
+  { className = '', variant = 'default', ...props },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      className={clsx('px-4 py-2 rounded transition-colors', variants[variant], className)}
+      {...props}
+    />
+  )
+})

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export const Card = React.forwardRef(function Card({ className = '', ...props }, ref) {
+  return <div ref={ref} className={`rounded-lg shadow ${className}`} {...props} />
+})
+
+export const CardHeader = ({ className = '', ...props }) => (
+  <div className={`border-b p-2 ${className}`} {...props} />
+)
+
+export const CardTitle = ({ className = '', ...props }) => (
+  <h3 className={`font-bold text-lg ${className}`} {...props} />
+)
+
+export const CardContent = ({ className = '', ...props }) => (
+  <div className={`p-2 ${className}`} {...props} />
+)

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+
+export const Dialog = DialogPrimitive.Root
+export const DialogTrigger = DialogPrimitive.Trigger
+
+export const DialogContent = React.forwardRef(function DialogContent(
+  { className = '', ...props },
+  ref
+) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 bg-black/50" />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={`fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white p-4 rounded-lg shadow ${className}`}
+        {...props}
+      />
+    </DialogPrimitive.Portal>
+  )
+})
+
+export const DialogHeader = ({ className = '', ...props }) => (
+  <div className={`mb-2 ${className}`} {...props} />
+)
+
+export const DialogTitle = ({ className = '', ...props }) => (
+  <DialogPrimitive.Title className={`font-bold text-lg ${className}`} {...props} />
+)

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const Input = React.forwardRef(function Input({ className = '', ...props }, ref) {
+  return <input ref={ref} className={`border rounded px-2 py-1 ${className}`} {...props} />
+})

--- a/src/components/ui/textarea.jsx
+++ b/src/components/ui/textarea.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const Textarea = React.forwardRef(function Textarea({ className = '', ...props }, ref) {
+  return <textarea ref={ref} className={`border rounded px-2 py-1 ${className}`} {...props} />
+})


### PR DESCRIPTION
## Summary
- add barebones UI components under `src/components/ui`
- ensure build and tests work without missing module errors

## Testing
- `pnpm exec vitest run`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868fac196888326bdeb796456b315c3